### PR TITLE
refactor: change the structure of the app so all the fetch logic resi…

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,66 +12,25 @@ import Fab from '@mui/material/Fab';
 import Link from '@mui/material/Link'
 import AddIcon from '@mui/icons-material/Add';
 import {useEffect, useState} from 'react';
-import { BrowserRouter, Routes, Route, Link as RouterLink } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Link as RouterLink } from 'react-router-dom';
+import { fetchEntries, updateEntry } from './api';
 
 
 function App() {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [diaryData, setDiaryData] = useState([])
 
-  const apiUrl = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test' ? 'http://localhost:9000' : 'https://my-site-diary.onrender.com'
 
+  // TODO: remove useEffect from App component at all once dashboard and diary page is refactored
   useEffect( () => {
     const getDiaries = async () => {
-      const diariesFromServer = await fetchDiaries(`${apiUrl}/api/diaries`)
+      const diariesFromServer = await fetchEntries();
       setDiaryData(diariesFromServer)
     }
 
     getDiaries()
-  },[apiUrl])
+  }, []);
 
-  //Fetch diaries
-  // can be wrapped into useCallback
-  const fetchDiaries = async (url) => {
-    const res = await fetch(url)
-    const data = await res.json()
-
-    return data
-  }
-
-  // Fetch diary
-  // const fetchDiary = async (id) => {
-  //   const res = await fetch(`${apiURL}/api/diaries/${id}`)
-  //   const data = await res.json()
-
-  //   return data
-  // }
-
-  //Add diary
-  const saveDiary = async (diary) => {
-    const res = await fetch(`${apiUrl}/api/diaries/add`, {
-      method: 'POST',
-      headers: {
-        'Content-type': 'application/json',
-      },
-      body: JSON.stringify(diary),
-    })
-
-    const data = await res.json()
-
-    setDiaryData([...diaryData, data])
-  }
-
-  //Delete diary
-  const deleteDiary = async (id) => {
-    const res = await fetch(`${apiUrl}/api/diaries/${id}`, {
-      method: 'DELETE',
-    })
-    //We should control the response status to decide if we will change the state or not.
-    res.status === 200
-      ? setDiaryData(diaryData.filter((diary) => diary._id !== id))
-      : alert('Error Deleting This Task')
-  }
   
   const fabStyle = {
     margin: 0,
@@ -82,27 +41,7 @@ function App() {
     position: 'fixed',
 };
 
-//Edit diary
-const editDiary = async (newDiary, id) => {
-  // const diaryToUpdate = await fetchTask(id)
-
-  const res = await fetch(`${apiUrl}/api/diaries/${id}`, {
-    method: 'PUT',
-    headers: {
-      'Content-type': 'application/json',
-    },
-    body: JSON.stringify(newDiary),
-  })
-
-  const data = await res.json()
-
-  setDiaryData(
-    diaryData.map((diary) =>
-      diary._id === id ? data : diary
-    )
-  )
-}
-
+// TODO: Reuse /diaries/:id as diaries/edit/:id
   return (
     <BrowserRouter>
       <Navbar sideBarClick={() => setIsDrawerOpen(true)}/>
@@ -111,11 +50,11 @@ const editDiary = async (newDiary, id) => {
         <Route path="/" element={<Home />}/>
         <Route path="/signup" element={<Signup />}/>
         <Route path="/signin" element={<Signin />}/>
-        <Route path="/dashboard" element={<Dashboard diaries={diaryData} deleteDiary={deleteDiary}/>}/>
-        <Route path="/diaries" element={<Diaries diaries={diaryData}/>}/>
-        <Route path="/diaries/:id" element={<Diary diaries={diaryData}/>}/>
-        <Route path="/diaries/add" element={<AddDiary saveDiary={saveDiary}/>}/>
-        <Route path="/diaries/edit/:id" element={<EditDiary editDiary={editDiary} diaries={diaryData}/>}/>
+        <Route path="/dashboard" element={<Dashboard diaries={diaryData} />}/>
+        <Route path="/diaries" element={<Diaries />}/>
+        <Route path="/diaries/:id" element={<Diary diaries={diaryData}/>} />
+        <Route path="/diaries/add" element={<AddDiary />}/>
+        <Route path="/diaries/edit/:id" element={<EditDiary editDiary={updateEntry} diaries={diaryData}/>}/>
       </Routes>
       <Link component={RouterLink} to='/diaries/add'>
         <Fab style={fabStyle} color="success" aria-label="add">

--- a/client/src/api/createEntry.js
+++ b/client/src/api/createEntry.js
@@ -1,0 +1,13 @@
+import { apiUrl } from '../utils'
+
+export const createEntry = async (diary) => {
+    const res = await fetch(`${apiUrl}/api/diaries/add`, {
+      method: 'POST',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(diary),
+    })
+
+    return await res.json();
+  }

--- a/client/src/api/deleteEntry.js
+++ b/client/src/api/deleteEntry.js
@@ -1,0 +1,8 @@
+import { apiUrl } from '../utils'
+export const deleteEntry = async (id) => {
+    const res = await fetch(`${apiUrl}/api/diaries/${id}`, {
+      method: 'DELETE',
+    })
+    //We should control the response status to decide if we will change the state or not.
+    return res;
+  }

--- a/client/src/api/fetchEntries.js
+++ b/client/src/api/fetchEntries.js
@@ -1,0 +1,6 @@
+import { apiUrl } from '../utils';
+
+export const fetchEntries = async () => {
+    const res = await fetch(`${apiUrl}/api/diaries`);
+    return await res.json();
+  };

--- a/client/src/api/fetchEntry.js
+++ b/client/src/api/fetchEntry.js
@@ -1,0 +1,6 @@
+import { apiUrl } from '../utils';
+
+export const fetchEntry = async (id) => {
+    const res = await fetch(`${apiUrl}/api/diaries/${id}`);
+    return await res.json();
+  }

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -1,0 +1,5 @@
+export { fetchEntries } from './fetchEntries';
+export { fetchEntry } from './fetchEntry';
+export { createEntry } from './createEntry';
+export { deleteEntry } from './deleteEntry';
+export { updateEntry } from './updateEntry';

--- a/client/src/api/updateEntry.js
+++ b/client/src/api/updateEntry.js
@@ -1,0 +1,14 @@
+import { apiUrl } from '../utils';
+
+export const updateEntry = async (newDiary, id) => {  
+    const res = await fetch(`${apiUrl}/api/diaries/${id}`, {
+      method: 'PUT',
+      headers: {
+        'Content-type': 'application/json',
+      },
+      body: JSON.stringify(newDiary),
+    })
+  
+    return await res.json();
+  
+  }

--- a/client/src/pages/AddDiary.js
+++ b/client/src/pages/AddDiary.js
@@ -8,9 +8,10 @@ import TextField from '@mui/material/TextField'
 import Button from '@mui/material/Button' 
 import { Link as RouterLink, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
+import { createEntry } from '../api/createEntry'
 
 
-const AddDiary = ({ saveDiary }) => {
+const AddDiary = () => {
     const navigate = useNavigate();
 
     const [project, setProject] = useState('')
@@ -26,7 +27,8 @@ const AddDiary = ({ saveDiary }) => {
     const onSubmit = (e) => {
         e.preventDefault()
         const date = Date.now()
-        saveDiary({date, project, weather, resource, delays, variations, healthsafety, deliveries, notes})
+        createEntry({date, project, weather, resource, delays, variations, healthsafety, deliveries, notes})
+        // TODO: handle success error cases
         setProject('')
         setWeather('')
         setResource('')
@@ -37,6 +39,7 @@ const AddDiary = ({ saveDiary }) => {
         setNotes('')
 
         navigate('/dashboard')
+        // TODO: refetch all entries on the dashboard page, alternatively, add new diary using state management
     }
 
   return (

--- a/client/src/pages/Dashboard.js
+++ b/client/src/pages/Dashboard.js
@@ -4,8 +4,9 @@ import Container from '@mui/material/Container'
 import Typography from '@mui/material/Typography'
 import DiariesTable from '../components/DiariesTable'
 import Divider from '@mui/material/Divider'
+import { deleteEntry } from '../api/deleteEntry'
 
-const Dashboard = ({diaries, deleteDiary}) => {
+const Dashboard = ({diaries}) => {
   return (
     <Container maxWidth='xs'>
       <Box sx={{mt: 4}}>
@@ -17,7 +18,7 @@ const Dashboard = ({diaries, deleteDiary}) => {
           <Divider />
           <Typography fontWeight="fontWeightMedium" variant="body1" gutterBottom>No diaries to show</Typography>
         </> :
-        <DiariesTable diaries={diaries} deleteDiary={deleteDiary}/>
+        <DiariesTable diaries={diaries} deleteDiary={deleteEntry}/>
       }
       </Box>
     </Container>

--- a/client/src/pages/Diaries.js
+++ b/client/src/pages/Diaries.js
@@ -2,14 +2,34 @@ import DiariesTable from "../components/DiariesTable"
 import Container from "@mui/material/Container"
 import Typography from "@mui/material/Typography"
 import Box from "@mui/material/Box"
+import {useEffect, useState} from 'react';
+import { apiUrl } from '../utils';
 
-const Diaries = ({diaries}) => {
+const fetchDiaries = async (url) => {
+  const res = await fetch(url)
+  const data = await res.json()
+
+  return data
+};
+
+const Diaries = () => {
+  const [diaryData, setDiaryData] = useState([]);
+
+  useEffect( () => {
+    const getDiaries = async () => {
+      const diariesFromServer = await fetchDiaries(`${apiUrl}/api/diaries`)
+      setDiaryData(diariesFromServer)
+    }
+    getDiaries()
+  },[]);
+
+
   return (
     <Container maxWidth="xs">
         <Box sx={{mt: 4}}>
             <Typography variant="h3" gutterBottom>Project Diaries</Typography>
             <Typography variant="subtitle1" gutterBottom>Here are all project diaries:</Typography>
-            <DiariesTable diaries={diaries}/>
+            <DiariesTable diaries={diaryData}/>
         </Box>
     </Container>
     

--- a/client/src/utils/apiUrl.js
+++ b/client/src/utils/apiUrl.js
@@ -1,0 +1,1 @@
+export const apiUrl = process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test' ? 'http://localhost:9000' : 'https://my-site-diary.onrender.com';

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -1,0 +1,1 @@
+export { apiUrl } from './apiUrl';


### PR DESCRIPTION
Addressed in this PR:
1. Change the structure of the app so all the fetch logic resides in api
2. Create utils for some useful functions across the app

**Notes:** 
FetchDiaries doesn’t have to accept any params, moved the string logic to the fetching function itself because our component doesn’t have to care about it
We still need to have a diary:id endpoint to get only one post, not to filter it on the UI side

**Future proposals:**
Reuse diary:id route as to edit diary entry. In that case, we don’t need to refetch data to edit it once again.
Add .eslintrc file with rules
Update to typescript


**Weird bits:**
1. Add entry button appears on the Login screen - that should be the case I guess :)